### PR TITLE
Use pip install

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel setuptools
         python -m pip install numpy astropy pytest-remotedata pytest-astropy-header
-        python setup.py install
+        python -m pip install .
     - name: Test without remote data
       run: pytest pysynphot
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
+[project]
+name = "pysynphot"
+version = "2.0.1"
+dynamic = [
+    "description", 
+    "requires-python", 
+    "license", 
+    "authors", 
+    "classifiers", 
+    "dependencies"]
+
 [build-system]
 requires = [
     "setuptools>=30.3.0",


### PR DESCRIPTION
These appear to be all of the changes required to use pip as the installer.  I updated the toml file so that it has the appropriate version and so that it grabs some info from the old setup.py file.  I also updated the CI workflow yaml file to use 'pip install .'.