### PR TITLE
Numpy 2 migration

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip wheel setuptools
-        python -m pip install numpy astropy pytest-remotedata pytest-astropy-header
+        python -m pip install numpy==2.0.1 astropy pytest-remotedata pytest-astropy-header
         python -m pip install .
     - name: Test without remote data
       run: pytest pysynphot

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -48,11 +48,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip wheel setuptools
-        python -m pip install numpy pytest-remotedata pytest-astropy-header pytest-cov codecov requests
+        python -m pip install numpy==2.0.1 pytest-remotedata pytest-astropy-header pytest-cov codecov requests
         python -m pip install --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre --upgrade
         python -m pip install -e .
     # NOTE: If TRDS cannot take the hit, disable --remote-data

--- a/pysynphot/observationmode.py
+++ b/pysynphot/observationmode.py
@@ -247,7 +247,7 @@ class BaseObservationMode(object):
             if not line.startswith('#'):
                 tokens.append(line)
 
-        return N.float_(tokens)
+        return N.float64(tokens)
 
 
 class ObservationMode(BaseObservationMode):

--- a/pysynphot/spectrum.py
+++ b/pysynphot/spectrum.py
@@ -230,8 +230,8 @@ class Integrator(object):
 
         # Now check for monotonicity & enforce ascending
         sorted = N.sort(wave)
-        if not N.alltrue(sorted == wave):
-            if N.alltrue(sorted[::-1] == wave):
+        if not N.all(sorted == wave):
+            if N.all(sorted[::-1] == wave):
                 # monotonic descending is allowed
                 pass
             else:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires='>=3.6,<3.12',
     install_requires=[
         'astropy',
-        'numpy<2',
+        'numpy',
         'beautifulsoup4',
         'six'
     ],


### PR DESCRIPTION
This appears to be the extent of the changes required to get pysynphot working with numpy 2.  This includes changes to the CI workflow to ensure numpy 2.0.1 is being installed when testing.  The test logs show that the correct version is being installed for testing, and the tests are clean.