### PR TITLE
Fix pysynphot_etc CI Testing (HETC-944) 

### DIFF
--- a/pysynphot/test/test_spectral_element.py
+++ b/pysynphot/test/test_spectral_element.py
@@ -23,7 +23,7 @@ def test_sample_units():
      ('acs,wfc1,f775w,pol_v', 444.05),
      ('cos,boa,nuv,mirrora', 370.65),
      ('nicmos,1,f090m,dn', 559.59),
-     ('stis,0.2x29,mirror,fuvmama', 134.836982),
+     ('stis,0.2x29,mirror,fuvmama', 134.383663),
      ('wfc3,ir,f164n', 700.05),
      ('wfc3,uvis1,f336w', 158.44),
      ('wfc3,uvis2,f336w', 158.36)])


### PR DESCRIPTION
pysynphot_etc testing automatically disabled itself because tests hadn't been passing in months. I re-enabled the CI workflow, then checked the failing test. One of the STIS spec tests was no longer within the tolerance of the expected value:
https://github.com/spacetelescope/pysynphot_etc/actions/runs/17967921347/job/51103946892

This broke sometime between October 2nd, 2024 and October 9th, 2024. I PR'd some STIS scalar changes in the pyetc repo on October 15, 2024 (https://github.com/spacetelescope/pyetc/pull/2008), so I'm assuming this must have been due to some STIS data delivery at the time. Sean, does that track? If so, I'll update the pyetc pre-release table to include something about checking to make sure the pysynphot_etc tests are updated as well.